### PR TITLE
ihp46 Modal de envío de solicitud

### DIFF
--- a/src/components/modals/SendRequestModal/index.tsx
+++ b/src/components/modals/SendRequestModal/index.tsx
@@ -1,0 +1,83 @@
+import { createPortal } from "react-dom";
+import { MdClear } from "react-icons/md";
+import { Icon } from "@inubekit/icon";
+import { Stack } from "@inubekit/stack";
+import { Text } from "@inubekit/text";
+import { Button } from "@inubekit/button";
+import { useMediaQuery } from "@inubekit/hooks";
+import { Blanket } from "@inubekit/blanket";
+import { Divider } from "@inubekit/divider";
+
+import { spacing } from "@design/tokens/spacing/spacing";
+
+import { StyledModal, StyledContainerClose } from "./styles";
+
+export interface SendRequestModalProps {
+  descriptionText: string;
+  buttonText?: string;
+  title?: string;
+  portalId?: string;
+  secondaryButtonText?: string;
+  onCloseModal?: () => void;
+  onSubmitButtonClick?: () => void;
+  onSecondaryButtonClick?: () => void;
+}
+
+export function SendRequestModal(props: SendRequestModalProps) {
+  const {
+    descriptionText,
+    buttonText = "Enviar",
+    title = "Enviar solicitud",
+    portalId = "portal",
+    secondaryButtonText = "Cancelar",
+    onCloseModal,
+    onSubmitButtonClick,
+    onSecondaryButtonClick,
+  } = props;
+
+  const isMobile = useMediaQuery("(max-width: 700px)");
+  const portalNode = document.getElementById(portalId);
+
+  if (!portalNode) {
+    throw new Error(
+      "The portal node is not defined. Ensure the specific node exists in the DOM.",
+    );
+  }
+
+  return createPortal(
+    <Blanket>
+      <StyledModal $smallScreen={isMobile}>
+        <Stack alignItems="center" justifyContent="space-between">
+          <Text type="headline" size="small">
+            {title}
+          </Text>
+          <StyledContainerClose onClick={onCloseModal}>
+            <Stack alignItems="center" gap={spacing.s100}>
+              <Text>Cerrar</Text>
+              <Icon
+                icon={<MdClear />}
+                size="24px"
+                cursorHover
+                appearance="dark"
+              />
+            </Stack>
+          </StyledContainerClose>
+        </Stack>
+        <Divider />
+        <Text>{descriptionText}</Text>
+        <Stack justifyContent="end" gap={spacing.s250}>
+          <Button
+            type="button"
+            variant="outlined"
+            appearance="gray"
+            onClick={onSecondaryButtonClick}
+          >
+            {secondaryButtonText}
+          </Button>
+          <Button onClick={onSubmitButtonClick}>{buttonText}</Button>
+        </Stack>
+      </StyledModal>
+    </Blanket>,
+    portalNode,
+  );
+}

--- a/src/components/modals/SendRequestModal/stories/SendRequestModal.stories.tsx
+++ b/src/components/modals/SendRequestModal/stories/SendRequestModal.stories.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { StoryFn, Meta } from "@storybook/react";
+import { Button } from "@inubekit/button";
+
+import { SendRequestModal, SendRequestModalProps } from "..";
+import { props } from "./props";
+
+const story: Meta<typeof SendRequestModal> = {
+  component: SendRequestModal,
+  title: "components/modals/SendRequestModal",
+  argTypes: props,
+};
+
+const DefaultTemplate: StoryFn<SendRequestModalProps> = (args) => {
+  const [showModal, setShowModal] = useState(false);
+
+  const handleShowModal = () => {
+    setShowModal(!showModal);
+  };
+
+  return (
+    <>
+      <Button onClick={handleShowModal}>Open Modal</Button>
+      {showModal && (
+        <SendRequestModal {...args} onCloseModal={handleShowModal} />
+      )}
+    </>
+  );
+};
+
+export const Default = DefaultTemplate.bind({});
+Default.args = {
+  descriptionText: "Lorem ipsum dolor sit, amet consectetur adipisicing elit.",
+};
+
+export default story;

--- a/src/components/modals/SendRequestModal/stories/props.ts
+++ b/src/components/modals/SendRequestModal/stories/props.ts
@@ -1,0 +1,45 @@
+import { ArgTypes } from "@storybook/react";
+
+import { SendRequestModalProps } from "..";
+
+const props: Partial<ArgTypes<SendRequestModalProps>> = {
+  descriptionText: {
+    control: "text",
+    description: "Text displayed as the description in the modal",
+    required: true,
+  },
+  buttonText: {
+    control: "text",
+    description: "Text for the primary submit button",
+    defaultValue: "Enviar",
+  },
+  title: {
+    control: "text",
+    description: "Title of the modal",
+    defaultValue: "Enviar solicitud",
+  },
+  portalId: {
+    control: "text",
+    description: "ID of the portal node for rendering the modal",
+    defaultValue: "portal",
+  },
+  secondaryButtonText: {
+    control: "text",
+    description: "Text for the secondary button",
+    defaultValue: "Cancelar",
+  },
+  onCloseModal: {
+    action: "closed",
+    description: "Function triggered when the modal is closed",
+  },
+  onSubmitButtonClick: {
+    action: "submitted",
+    description: "Function triggered when the submit button is clicked",
+  },
+  onSecondaryButtonClick: {
+    action: "secondaryButtonClicked",
+    description: "Function triggered when the secondary button is clicked",
+  },
+};
+
+export { props };

--- a/src/components/modals/SendRequestModal/styles.ts
+++ b/src/components/modals/SendRequestModal/styles.ts
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+import { inube } from "@inubekit/foundations";
+
+import { spacing } from "@design/tokens/spacing/spacing";
+
+interface IStyledModal {
+  $smallScreen: boolean;
+  theme?: typeof inube;
+}
+
+const StyledModal = styled.div<IStyledModal>`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background-color: ${({ theme }) =>
+    theme?.palette?.neutral?.N0 || inube.palette.neutral.N0};
+  height: ${({ $smallScreen }) => ($smallScreen ? "174px" : "182px")};
+  width: ${({ $smallScreen }) => ($smallScreen ? "303px" : "402px")};
+  padding: ${({ $smallScreen }) =>
+    $smallScreen ? spacing.s200 : spacing.s300};
+  gap: ${({ $smallScreen }) => ($smallScreen ? spacing.s200 : spacing.s250)};
+  border-radius: ${spacing.s100};
+`;
+
+const StyledContainerClose = styled.div`
+  cursor: pointer;
+`;
+
+export { StyledModal, StyledContainerClose };

--- a/src/pages/certifications/NewCertification/forms/VerificationForm/index.tsx
+++ b/src/pages/certifications/NewCertification/forms/VerificationForm/index.tsx
@@ -13,12 +13,13 @@ import { VerificationBoxes } from "./VerificationBoxes";
 interface VerificationFormProps {
   updatedData: IFormsUpdateData;
   handleStepChange: (stepId: number) => void;
+  handlePreviousStep: () => void;
+  handleSubmit: () => void;
 }
 
-function VerificationForm({
-  updatedData,
-  handleStepChange,
-}: VerificationFormProps) {
+function VerificationForm(props: VerificationFormProps) {
+  const { updatedData, handleStepChange, handlePreviousStep, handleSubmit } =
+    props;
   const isTablet = useMediaQuery("(max-width: 1224px)");
 
   return (
@@ -50,6 +51,23 @@ function VerificationForm({
             </Stack>
           </Accordion>
         ))}
+      <Stack
+        direction="row"
+        justifyContent="flex-end"
+        alignItems="center"
+        gap={spacing.s250}
+      >
+        <Button
+          onClick={handlePreviousStep}
+          variant="outlined"
+          appearance="gray"
+        >
+          Anterior
+        </Button>
+        <Button onClick={handleSubmit} appearance="primary">
+          Enviar
+        </Button>
+      </Stack>
     </Stack>
   );
 }

--- a/src/pages/certifications/NewCertification/index.tsx
+++ b/src/pages/certifications/NewCertification/index.tsx
@@ -1,12 +1,19 @@
 import { useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { FormikProps } from "formik";
+
+import { SendRequestModal } from "@components/modals/SendRequestModal";
 
 import { newCCertificationApplication } from "./config/assisted.config";
 import { certificationsNavConfig } from "../config/nav.config";
 import { NewCertificationUI } from "./interface";
 import { IGeneralInformationEntry } from "./forms/GeneralInformationForm/types";
+import { RequestInfoModal } from "./modals/RequestInfoModal";
+import { ModalState } from "./types";
 
 function NewCertification() {
+  const navigate = useNavigate();
+
   const [currentStep, setCurrentStep] = useState(1);
   const [formValues, setFormValues] = useState<IGeneralInformationEntry>({
     id: "",
@@ -16,22 +23,26 @@ function NewCertification() {
     contractDesc: "",
     contract: "",
   });
+  const [isCurrentFormValid, setIsCurrentFormValid] = useState(false);
+
+  const [modalState, setModalState] = useState<ModalState>({
+    isSendModalVisible: false,
+    isRequestInfoModalVisible: false,
+  });
 
   const generalInformationRef =
     useRef<FormikProps<IGeneralInformationEntry>>(null);
 
-  const [isCurrentFormValid, setIsCurrentFormValid] = useState(false);
+  const updateFormValues = () => {
+    if (generalInformationRef.current) {
+      setFormValues(generalInformationRef.current.values);
+      setIsCurrentFormValid(generalInformationRef.current.isValid);
+    }
+  };
 
   const handleNextStep = () => {
     if (currentStep < newCCertificationApplication.length) {
-      if (generalInformationRef.current) {
-        setFormValues(generalInformationRef.current.values);
-        setIsCurrentFormValid(generalInformationRef.current.isValid);
-      }
-      if (generalInformationRef.current) {
-        setFormValues(generalInformationRef.current.values);
-        setIsCurrentFormValid(generalInformationRef.current.isValid);
-      }
+      updateFormValues();
       setCurrentStep(currentStep + 1);
     }
   };
@@ -43,25 +54,67 @@ function NewCertification() {
   };
 
   const handleFinishAssisted = () => {
-    console.log("Proceso de certificación completado");
+    setModalState((prev) => ({ ...prev, isSendModalVisible: true }));
   };
 
+  const handleCloseSendModal = () => {
+    setModalState((prev) => ({ ...prev, isSendModalVisible: false }));
+  };
+
+  const handleConfirmSendModal = () => {
+    setModalState({
+      isSendModalVisible: false,
+      isRequestInfoModalVisible: true,
+    });
+  };
+
+  const handleSubmitRequestInfoModal = () => {
+    setModalState((prev) => ({ ...prev, isRequestInfoModalVisible: false }));
+    navigate("/certifications");
+  };
+
+  const {
+    label: appName,
+    crumbs: appRoute,
+    url: navigatePage,
+  } = certificationsNavConfig[1];
+
   return (
-    <NewCertificationUI
-      appName={certificationsNavConfig[1].label}
-      appRoute={certificationsNavConfig[1].crumbs}
-      navigatePage={certificationsNavConfig[1].url}
-      steps={newCCertificationApplication}
-      currentStep={currentStep}
-      handleNextStep={handleNextStep}
-      handlePreviousStep={handlePreviousStep}
-      handleFinishAssisted={handleFinishAssisted}
-      setIsCurrentFormValid={setIsCurrentFormValid}
-      setCurrentStep={setCurrentStep}
-      isCurrentFormValid={isCurrentFormValid}
-      generalInformationRef={generalInformationRef}
-      initialGeneralInformationValues={formValues}
-    />
+    <>
+      <NewCertificationUI
+        appName={appName}
+        appRoute={appRoute}
+        navigatePage={navigatePage}
+        steps={newCCertificationApplication}
+        currentStep={currentStep}
+        handleNextStep={handleNextStep}
+        handlePreviousStep={handlePreviousStep}
+        handleFinishAssisted={handleFinishAssisted}
+        setIsCurrentFormValid={setIsCurrentFormValid}
+        setCurrentStep={setCurrentStep}
+        isCurrentFormValid={isCurrentFormValid}
+        generalInformationRef={generalInformationRef}
+        initialGeneralInformationValues={formValues}
+      />
+
+      {modalState.isSendModalVisible && (
+        <SendRequestModal
+          descriptionText="¿Realmente deseas enviar la solicitud de certificación?"
+          onSubmitButtonClick={handleConfirmSendModal}
+          onCloseModal={handleCloseSendModal}
+          onSecondaryButtonClick={handleCloseSendModal}
+        />
+      )}
+
+      {modalState.isRequestInfoModalVisible && (
+        <RequestInfoModal
+          requestId="#45678822"
+          staffName="Nombre Nombre Apellido Apellido"
+          onCloseModal={handleSubmitRequestInfoModal}
+          onSubmitButtonClick={handleSubmitRequestInfoModal}
+        />
+      )}
+    </>
   );
 }
 

--- a/src/pages/certifications/NewCertification/interface.tsx
+++ b/src/pages/certifications/NewCertification/interface.tsx
@@ -86,6 +86,8 @@ function NewCertificationUI(
               },
             }}
             handleStepChange={(stepId) => setCurrentStep(stepId)}
+            handlePreviousStep={handlePreviousStep}
+            handleSubmit={handleFinishAssisted}
           />
         )}
       </Stack>

--- a/src/pages/certifications/NewCertification/modals/RequestInfoModal/index.tsx
+++ b/src/pages/certifications/NewCertification/modals/RequestInfoModal/index.tsx
@@ -1,0 +1,84 @@
+import { createPortal } from "react-dom";
+import { MdClear, MdCheckCircle } from "react-icons/md";
+import { Icon } from "@inubekit/icon";
+import { Stack } from "@inubekit/stack";
+import { Text } from "@inubekit/text";
+import { Button } from "@inubekit/button";
+import { useMediaQuery } from "@inubekit/hooks";
+import { Blanket } from "@inubekit/blanket";
+import { Divider } from "@inubekit/divider";
+
+import { spacing } from "@design/tokens/spacing/spacing";
+
+import { StyledModal, StyledContainerClose } from "./styles";
+
+export interface RequestInfoModalProps {
+  requestId: string;
+  staffName: string;
+  buttonText?: string;
+  title?: string;
+  portalId?: string;
+  onCloseModal?: () => void;
+  onSubmitButtonClick?: () => void;
+}
+
+export function RequestInfoModal(props: RequestInfoModalProps) {
+  const {
+    requestId,
+    staffName,
+    buttonText = "Entendido",
+    title = "Solicitud",
+    portalId = "portal",
+    onCloseModal,
+    onSubmitButtonClick,
+  } = props;
+
+  const isMobile = useMediaQuery("(max-width: 700px)");
+  const portalNode = document.getElementById(portalId);
+
+  if (!portalNode) {
+    throw new Error(
+      "The portal node is not defined. Ensure the specific node exists in the DOM.",
+    );
+  }
+
+  return createPortal(
+    <Blanket>
+      <StyledModal $smallScreen={isMobile}>
+        <Stack alignItems="center" justifyContent="space-between">
+          <Text type="headline" size="small">
+            {title}
+          </Text>
+          <StyledContainerClose onClick={onCloseModal}>
+            <Stack alignItems="center" gap={spacing.s100}>
+              <Text>Cerrar</Text>
+              <Icon
+                icon={<MdClear />}
+                size="24px"
+                cursorHover
+                appearance="dark"
+              />
+            </Stack>
+          </StyledContainerClose>
+        </Stack>
+        <Divider />
+        <Stack direction="column" alignItems="center" gap={spacing.s300}>
+          <Icon icon={<MdCheckCircle />} size="68px" appearance="primary" />
+          <Text>
+            Solicitud <b>{requestId}</b>
+          </Text>
+          <Text size="medium">
+            Este proceso será gestionado por {staffName}, puede tardar algún
+            tiempo mientras se gestiona la aprobación.
+          </Text>
+        </Stack>
+        <Stack justifyContent="end">
+          <Button onClick={onSubmitButtonClick} fullwidth={isMobile}>
+            {buttonText}
+          </Button>
+        </Stack>
+      </StyledModal>
+    </Blanket>,
+    portalNode,
+  );
+}

--- a/src/pages/certifications/NewCertification/modals/RequestInfoModal/stories/RequestInfoModal.stories.tsx
+++ b/src/pages/certifications/NewCertification/modals/RequestInfoModal/stories/RequestInfoModal.stories.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { StoryFn, Meta } from "@storybook/react";
+import { Button } from "@inubekit/button";
+
+import { RequestInfoModal, RequestInfoModalProps } from "..";
+import { props } from "./props";
+
+const story: Meta<typeof RequestInfoModal> = {
+  component: RequestInfoModal,
+  title: "modals/RequestInfoModal",
+  argTypes: props,
+};
+
+const DefaultTemplate: StoryFn<RequestInfoModalProps> = (args) => {
+  const [showModal, setShowModal] = useState(false);
+
+  const handleShowModal = () => {
+    setShowModal(!showModal);
+  };
+
+  return (
+    <>
+      <Button onClick={handleShowModal}>Open Modal</Button>
+      {showModal && (
+        <RequestInfoModal {...args} onCloseModal={handleShowModal} />
+      )}
+    </>
+  );
+};
+
+export const Default = DefaultTemplate.bind({});
+Default.args = {
+  requestId: "#45678822",
+  staffName: "Nombre Nombre Apellido Apellido",
+};
+
+export default story;

--- a/src/pages/certifications/NewCertification/modals/RequestInfoModal/stories/props.ts
+++ b/src/pages/certifications/NewCertification/modals/RequestInfoModal/stories/props.ts
@@ -1,0 +1,41 @@
+import { ArgTypes } from "@storybook/react";
+
+import { RequestInfoModalProps } from "..";
+
+const props: Partial<ArgTypes<RequestInfoModalProps>> = {
+  requestId: {
+    control: "text",
+    description: "Unique identifier for the request",
+    required: true,
+  },
+  staffName: {
+    control: "text",
+    description: "Name of the staff managing the request",
+    required: true,
+  },
+  buttonText: {
+    control: "text",
+    description: "Text for the primary submit button",
+    defaultValue: "Entendido",
+  },
+  title: {
+    control: "text",
+    description: "Title of the modal",
+    defaultValue: "Solicitud",
+  },
+  portalId: {
+    control: "text",
+    description: "ID of the portal node for rendering the modal",
+    defaultValue: "portal",
+  },
+  onCloseModal: {
+    action: "closed",
+    description: "Function triggered when the modal is closed",
+  },
+  onSubmitButtonClick: {
+    action: "submitted",
+    description: "Function triggered when the submit button is clicked",
+  },
+};
+
+export { props };

--- a/src/pages/certifications/NewCertification/modals/RequestInfoModal/styles.ts
+++ b/src/pages/certifications/NewCertification/modals/RequestInfoModal/styles.ts
@@ -1,0 +1,28 @@
+import styled from "styled-components";
+import { inube } from "@inubekit/foundations";
+
+import { spacing } from "@design/tokens/spacing/spacing";
+
+interface IStyledModal {
+  $smallScreen: boolean;
+  theme?: typeof inube;
+}
+
+const StyledModal = styled.div<IStyledModal>`
+  display: flex;
+  flex-direction: column;
+  background-color: ${({ theme }) =>
+    theme?.palette?.neutral?.N0 || inube.palette.neutral.N0};
+  height: ${({ $smallScreen }) => ($smallScreen ? "318px" : "326px")};
+  width: ${({ $smallScreen }) => ($smallScreen ? "303px" : "402px")};
+  padding: ${({ $smallScreen }) =>
+    $smallScreen ? spacing.s200 : spacing.s300};
+  gap: ${({ $smallScreen }) => ($smallScreen ? spacing.s200 : spacing.s200)};
+  border-radius: ${spacing.s100};
+`;
+
+const StyledContainerClose = styled.div`
+  cursor: pointer;
+`;
+
+export { StyledModal, StyledContainerClose };

--- a/src/pages/certifications/NewCertification/types.ts
+++ b/src/pages/certifications/NewCertification/types.ts
@@ -3,3 +3,8 @@ import { IGeneralInformationEntry } from "./forms/GeneralInformationForm/types";
 export interface IFormsUpdateData {
   personalInformation: { isValid: boolean; values: IGeneralInformationEntry };
 }
+
+export interface ModalState {
+  isSendModalVisible: boolean;
+  isRequestInfoModalVisible: boolean;
+}


### PR DESCRIPTION
Realizar la modales de envió de solicitud tal como lo muestra el [figma](https://www.figma.com/design/cpXEJp5TQdTGwVcnZ1YrIM/Employee-portal?node-id=198-6095&t=iPf5EguvfxWKTFrU-0) para la opción de certificado

En esta modal desencadena en el botón de enviar del asistido de nueva de certificación

![image](https://github.com/user-attachments/assets/c6cc038d-2a18-40b6-8ba8-5885eff05c4d)
Si el usuario da clic en enviar debe desencadenar la siguiente modal que se crea también en esta incidencia

![image](https://github.com/user-attachments/assets/e91c559f-7e9c-42a1-86a6-1e35541408e3)
Nota: no implementar ningun entpoint

Criterios de aceptación:

Se debe crear las mismas medidas que tenga el mockup

Se debe crear las dos modales de las anteriores imágenes

 Debe tener stroybook

La opción se debe desencadenar cuando se envié la solicitud en el asistido de nueva certificación

Si se cierra las modales lo debe dirigir a la consulta de certificaciones en tramite 

![image](https://github.com/user-attachments/assets/9c6ad78a-cb80-4d82-b8ad-1bae3f738801)