### PR TITLE
at/ihp108/adjust-requirements-table-in-mobile-version

### DIFF
--- a/src/components/data/TableBoard/interface.tsx
+++ b/src/components/data/TableBoard/interface.tsx
@@ -242,6 +242,9 @@ export const TableBoardUI = (props: ITableBoardUIProps) => {
                       </Stack>
                     </StyledTd>
                   ))}
+                  {isTablet &&
+                    appearanceTable!.isStyleMobile &&
+                    isFirstTable && <StyledTdactions $isTablet={isTablet} />}
                   {actions && (
                     <Actions
                       actions={actions}

--- a/src/components/modals/ComponentDetailModal/index.tsx
+++ b/src/components/modals/ComponentDetailModal/index.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   Icon,
   Text,
@@ -184,6 +185,8 @@ function RequestComponentDetail(props: RequestComponentDetailProps) {
                     id={requirement.id}
                     titles={requirement.titles}
                     entries={requirement.entries}
+                    actions={[]}
+                    actionMobile={[]}
                     actionMobileIcon={getActionsMobileIcon()}
                     appearanceTable={{
                       widthTd: "75%",


### PR DESCRIPTION
A table with the application requirements is displayed in the vacation and certification details window. The information icon is not displayed in the mobile version.

![image](https://github.com/user-attachments/assets/8f51ce5d-2f67-4f89-8f6f-123069aa64d6)
