### PR TITLE
At/ihp233/include menu icon from the database

### DIFF
--- a/src/components/layout/AppPage/index.tsx
+++ b/src/components/layout/AppPage/index.tsx
@@ -7,6 +7,7 @@ import {
   actions,
   useConfigHeader,
 } from "@config/nav.config";
+import { useEmployeeOptions } from "@hooks/useEmployeeOptions";
 import { useAppContext } from "@context/AppContext/useAppContext";
 import { useContractValidation } from "@hooks/useContractValidation";
 
@@ -38,8 +39,11 @@ function AppPage(props: AppPageProps) {
   const { user, logoUrl, businessUnit } = useAppContext();
   const isTablet = useMediaQuery("(max-width: 944px)");
 
-  const navConfig = useNavConfig();
-  const configHeader = useConfigHeader();
+  const { data: employeeOptions } = useEmployeeOptions(user?.id ?? "");
+  const safeEmployeeOptions = employeeOptions ?? [];
+
+  const navConfig = useNavConfig(safeEmployeeOptions);
+  const configHeader = useConfigHeader(safeEmployeeOptions);
 
   useContractValidation();
 

--- a/src/config/nav.config.tsx
+++ b/src/config/nav.config.tsx
@@ -1,18 +1,14 @@
-import {
-  MdLogout,
-  MdOutlineFilePresent,
-  MdOutlineBeachAccess,
-  MdOutlinePersonalInjury,
-  MdOutlinePersonOff,
-} from "react-icons/md";
+import { MdLogout } from "react-icons/md";
 import { ILinkNav } from "@inubekit/inubekit";
 import { useLocation } from "react-router-dom";
+import { ReactNode } from "react";
+
+import { IEmployeeOptions } from "@ptypes/employeePortalBusiness.types";
 
 const baseNavLinks = [
   {
     id: "holidays",
     label: "Vacaciones",
-    icon: <MdOutlineBeachAccess />,
     path: "/holidays",
     description:
       "Son los días de descanso remunerado que le corresponden al empleado por cada año trabajado.",
@@ -20,26 +16,23 @@ const baseNavLinks = [
   {
     id: "disability",
     label: "Incapacidades",
-    icon: <MdOutlinePersonalInjury />,
     path: "/disability",
     description:
       "Son períodos en los que el trabajador no puede laborar debido a una enfermedad o accidente, y está respaldado por un certificado médico.",
   },
   {
-    id: "certifications",
-    label: "Certificaciones",
-    icon: <MdOutlineFilePresent />,
-    path: "/certifications",
-    description:
-      "Son documentos que acreditan la formación o experiencia laboral de un empleado.",
-  },
-  {
     id: "absences",
     label: "Ausencias",
-    icon: <MdOutlinePersonOff />,
     path: "/absences",
     description:
       "Son períodos en los que el trabajador no se presenta a laborar, ya sea de forma justificada o injustificada.",
+  },
+  {
+    id: "certifications",
+    label: "Certificaciones",
+    path: "/certifications",
+    description:
+      "Son documentos que acreditan la formación o experiencia laboral de un empleado.",
   },
 ];
 
@@ -56,8 +49,35 @@ const actions = [
   },
 ];
 
-const useNavConfig = () => {
+const getIcon = (iconReference?: string): ReactNode => {
+  if (iconReference && iconReference.trim() !== "") {
+    return (
+      <img
+        src={iconReference}
+        alt="icon"
+        style={{ width: 24, height: 24, objectFit: "contain" }}
+      />
+    );
+  }
+  return <div style={{ width: 24, height: 24 }} />;
+};
+
+const navConfig = (employeeOptions: IEmployeeOptions[]) => {
+  return baseNavLinks.map((link) => {
+    const option = employeeOptions.find((opt) => opt.optionCode === link.id);
+
+    return {
+      ...link,
+      label: option?.abbreviatedName ?? link.label,
+      icon: getIcon(option?.iconReference),
+      isEnabled: !!option,
+    };
+  });
+};
+
+const useNavConfig = (employeeOptions: IEmployeeOptions[]) => {
   const location = useLocation();
+  const baseNav = navConfig(employeeOptions);
 
   const nav = {
     reactPortalId: "portals",
@@ -65,7 +85,7 @@ const useNavConfig = () => {
     sections: {
       administrate: {
         name: "",
-        links: baseNavLinks.reduce(
+        links: baseNav.reduce(
           (acc, link) => {
             acc[link.id] = {
               ...link,
@@ -83,7 +103,7 @@ const useNavConfig = () => {
   return nav;
 };
 
-const useConfigHeader = () => {
+const useConfigHeader = (employeeOptions: IEmployeeOptions[]) => {
   const nav = {
     reactPortalId: "portal",
     title: "MENU",
@@ -93,7 +113,7 @@ const useConfigHeader = () => {
         onClose: noop,
         onToggle: noop,
         subtitle: "Administrate",
-        links: baseNavLinks,
+        links: navConfig(employeeOptions),
       },
     ],
     actions,
@@ -127,4 +147,6 @@ export {
   userMenu,
   actions,
   pathStart,
+  navConfig,
+  getIcon,
 };

--- a/src/hooks/useContractValidation.ts
+++ b/src/hooks/useContractValidation.ts
@@ -5,11 +5,10 @@ import { useAppContext } from "@context/AppContext";
 import { useEmployee } from "@hooks/useEmployee";
 import { useErrorFlag } from "@hooks/useErrorFlag";
 import { EmploymentContract } from "@ptypes/employeePortalConsultation.types";
-
-const FORMALIZED_STATUS = "Formalized";
+import { EContractStatus } from "@ptypes/employeePortalBusiness.types";
 
 const isContractActive = (status: string, deadline: string): boolean => {
-  if (status !== FORMALIZED_STATUS) return false;
+  if (status !== EContractStatus.formalized) return false;
   if (!deadline) return true;
   const currentDate = new Date();
   const endDate = new Date(deadline);
@@ -20,7 +19,7 @@ const areAllContractsFinalized = (contracts: EmploymentContract[]): boolean => {
   if (!contracts || contracts.length === 0) return true;
   return contracts.every(
     (contract) =>
-      contract.contractStatus === "Finalized" ||
+      contract.contractStatus === EContractStatus.finalized ||
       !isContractActive(contract.contractStatus, contract.deadline),
   );
 };

--- a/src/hooks/useEmployeeInquiry.ts
+++ b/src/hooks/useEmployeeInquiry.ts
@@ -11,7 +11,7 @@ const validateContractStatus = (
 ): boolean => {
   if (!employmentContracts || employmentContracts.length === 0) return false;
   return employmentContracts.some(
-    (contract) => contract.contractStatus === EContractStatus.Formalized,
+    (contract) => contract.contractStatus === EContractStatus.formalized,
   );
 };
 

--- a/src/hooks/useHumanResourceRequests.ts
+++ b/src/hooks/useHumanResourceRequests.ts
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import {
   HumanResourceRequest,
   ERequestType,
+  requestTypeMap,
 } from "@ptypes/humanResourcesRequest.types";
 import { getHumanResourceRequests } from "@services/humanResourcesRequest/getHumanResourcesRequest";
 import { useHeaders } from "@hooks/useHeaders";
@@ -42,13 +43,18 @@ export const useHumanResourceRequests = <T>(
     if (!effectiveEmployeeId) return;
     setIsLoading(true);
     setFlagShown(false);
+
     try {
       const headers = await getHeaders();
+      // 👇 Traducción del tipo para backend
+      const backendType = typeRequest ? requestTypeMap[typeRequest] : undefined;
+
       const requests = await getHumanResourceRequests(
         effectiveEmployeeId,
         headers,
-        typeRequest,
+        backendType,
       );
+
       const requestsData = requests ?? [];
       setRawData(requestsData);
       setData(formatData(requestsData));

--- a/src/hooks/useHumanResourceRequests.ts
+++ b/src/hooks/useHumanResourceRequests.ts
@@ -1,15 +1,13 @@
 import { useState, useEffect } from "react";
-
+import { getHumanResourceRequests } from "@services/humanResourcesRequest/getHumanResourcesRequest";
 import {
   HumanResourceRequest,
   ERequestType,
   requestTypeMap,
+  requestTypeLabels,
 } from "@ptypes/humanResourcesRequest.types";
-import { getHumanResourceRequests } from "@services/humanResourcesRequest/getHumanResourcesRequest";
 import { useHeaders } from "@hooks/useHeaders";
 import { useAppContext } from "@context/AppContext";
-
-import { useContractValidation } from "./useContractValidation";
 import { useErrorFlag } from "./useErrorFlag";
 
 export const useHumanResourceRequests = <T>(
@@ -26,14 +24,12 @@ export const useHumanResourceRequests = <T>(
   const { getHeaders } = useHeaders();
   const { employees } = useAppContext();
 
-  useContractValidation();
-
   const effectiveEmployeeId = employeeId ?? employees?.employeeId;
 
   useErrorFlag(
     flagShown,
     typeRequest
-      ? `Error al obtener solicitudes de tipo "${typeRequest}"`
+      ? `Error al obtener solicitudes de tipo "${requestTypeLabels[typeRequest]}"`
       : "Error al obtener solicitudes",
     "Error en la solicitud",
     false,
@@ -46,7 +42,6 @@ export const useHumanResourceRequests = <T>(
 
     try {
       const headers = await getHeaders();
-      // 👇 Traducción del tipo para backend
       const backendType = typeRequest ? requestTypeMap[typeRequest] : undefined;
 
       const requests = await getHumanResourceRequests(

--- a/src/hooks/useHumanResourceRequests.ts
+++ b/src/hooks/useHumanResourceRequests.ts
@@ -11,11 +11,9 @@ import { useAppContext } from "@context/AppContext";
 import { useContractValidation } from "./useContractValidation";
 import { useErrorFlag } from "./useErrorFlag";
 
-type RequestType = keyof typeof ERequestType;
-
 export const useHumanResourceRequests = <T>(
   formatData: (data: HumanResourceRequest[]) => T[],
-  typeRequest: RequestType,
+  typeRequest?: ERequestType,
   employeeId?: string,
 ) => {
   const [data, setData] = useState<T[]>([]);
@@ -34,7 +32,7 @@ export const useHumanResourceRequests = <T>(
   useErrorFlag(
     flagShown,
     typeRequest
-      ? `Error al obtener solicitudes de tipo "${ERequestType[typeRequest]}"`
+      ? `Error al obtener solicitudes de tipo "${typeRequest}"`
       : "Error al obtener solicitudes",
     "Error en la solicitud",
     false,
@@ -47,9 +45,9 @@ export const useHumanResourceRequests = <T>(
     try {
       const headers = await getHeaders();
       const requests = await getHumanResourceRequests(
-        typeRequest,
         effectiveEmployeeId,
         headers,
+        typeRequest,
       );
       const requestsData = requests ?? [];
       setRawData(requestsData);

--- a/src/hooks/usePostHumanResourceRequest.ts
+++ b/src/hooks/usePostHumanResourceRequest.ts
@@ -52,7 +52,10 @@ export function useRequestSubmission(
           contractType: formValues.contractType ?? "",
           observationEmployee: formValues.observationEmployee ?? "",
         });
-      } else if (isVacationPaymentData(formValues)) {
+      } else if (
+        typeRequest === ERequestType.paid_vacations &&
+        isVacationPaymentData(formValues)
+      ) {
         humanResourceRequestData = JSON.stringify({
           daysToPay: formValues.daysToPay ?? "",
           disbursementDate: "",
@@ -62,7 +65,10 @@ export function useRequestSubmission(
           contractType: formValues.contractType ?? "",
           observationEmployee: formValues.observationEmployee ?? "",
         });
-      } else if (isVacationEnjoyedData(formValues)) {
+      } else if (
+        typeRequest === ERequestType.vacations_enjoyed &&
+        isVacationEnjoyedData(formValues)
+      ) {
         humanResourceRequestData = JSON.stringify({
           daysOff: formValues.daysOff ?? "",
           startDateEnyoment: formValues.startDateEnyoment
@@ -78,13 +84,17 @@ export function useRequestSubmission(
         throw new Error("Tipo de solicitud no reconocido.");
       }
 
+      const typeRequestKey = Object.keys(ERequestType).find(
+        (key) => ERequestType[key as keyof typeof ERequestType] === typeRequest,
+      ) as keyof typeof ERequestType;
+
       const requestBody = {
         employeeId: employees.employeeId,
         humanResourceRequestData,
         humanResourceRequestDate: new Date().toISOString(),
         humanResourceRequestDescription: formValues.observationEmployee ?? "",
         humanResourceRequestStatus: "supervisor_approval",
-        humanResourceRequestType: typeRequest,
+        humanResourceRequestType: typeRequestKey as ERequestType,
         userCodeInCharge,
         userNameInCharge,
       };
@@ -95,7 +105,7 @@ export function useRequestSubmission(
         setRequestNum(response.humanResourceRequestNumber);
 
         if (humanResourceRequestId) {
-          navigateAfterSubmission(typeRequest);
+          navigateAfterSubmission(typeRequestKey);
         }
 
         return true;

--- a/src/hooks/usePostHumanResourceRequest.ts
+++ b/src/hooks/usePostHumanResourceRequest.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { formatWithOffset } from "@utils/date";
 import { IUnifiedHumanResourceRequestData } from "@ptypes/humanResourcesRequest.types";
+import { ERequestType } from "@ptypes/humanResourcesRequest.types";
 import { useAppContext } from "@context/AppContext/useAppContext";
 
 import { useRequestSubmissionAPI } from "./useRequestSubmissionAPI";
@@ -19,7 +20,7 @@ function isVacationEnjoyedData(data: FormValues) {
 
 export function useRequestSubmission(
   formValues: FormValues,
-  typeRequest: string,
+  typeRequest: ERequestType,
   userCodeInCharge: string,
   userNameInCharge: string,
 ) {
@@ -41,7 +42,7 @@ export function useRequestSubmission(
     try {
       let humanResourceRequestData: string;
 
-      if (typeRequest === "Certification") {
+      if (typeRequest === ERequestType.certification) {
         humanResourceRequestData = JSON.stringify({
           certificationType: formValues.certificationType ?? "",
           addressee: formValues.addressee ?? "",

--- a/src/mocks/contracts/enums.ts
+++ b/src/mocks/contracts/enums.ts
@@ -1,10 +1,10 @@
 export const contractTypeLabels: Record<string, string> = {
-  Apprentice: "Aprendiz",
-  ByWorkOrLabor: "Por obra o labor",
-  CivilContract: "Contrato civil",
-  ContingentWorker: "Trabajador eventual",
-  FixedTermContract: "Termino Fijo",
-  PermanentJob: "Trabajo permanente",
+  apprentice: "Aprendiz",
+  by_work_or_labor: "Por obra o labor",
+  civil_contract: "Contrato civil por prestacion de servicios",
+  contingent_worker: "Contrato ocasional de trabajol",
+  fixed_term_contract: "Termino Fijo",
+  permanent_job: "Trabajo permanente",
 };
 
 export const workScheduleLabels: Record<string, string> = {

--- a/src/pages/certifications/NewCertification/index.tsx
+++ b/src/pages/certifications/NewCertification/index.tsx
@@ -4,6 +4,7 @@ import { useMediaQuery } from "@inubekit/inubekit";
 
 import { SendRequestModal } from "@components/modals/SendRequestModal";
 import { RequestInfoModal } from "@components/modals/RequestInfoModal";
+import { ERequestType } from "@ptypes/humanResourcesRequest.types";
 import { useErrorFlag } from "@hooks/useErrorFlag";
 import { useRequestSubmission } from "@hooks/usePostHumanResourceRequest";
 import { useAppContext } from "@context/AppContext/useAppContext";
@@ -125,7 +126,7 @@ function NewCertification() {
     setShowErrorFlag,
   } = useRequestSubmission(
     formValues,
-    "Certification",
+    ERequestType.certification,
     userCodeInCharge,
     userNameInCharge,
   );

--- a/src/pages/certifications/index.tsx
+++ b/src/pages/certifications/index.tsx
@@ -22,7 +22,7 @@ function CertificationsOptions() {
     error,
   } = useHumanResourceRequests<ICertificationsTable>(
     formatHumanResourceData,
-    "Certification",
+    "certification",
   );
   const [tableData, setTableData] = useState<ICertificationsTable[]>([]);
 

--- a/src/pages/certifications/index.tsx
+++ b/src/pages/certifications/index.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { useMediaQuery } from "@inubekit/inubekit";
 
 import { useHumanResourceRequests } from "@hooks/useHumanResourceRequests";
+import { ERequestType } from "@ptypes/humanResourcesRequest.types";
 import { useDeleteRequest } from "@hooks/useDeleteRequest";
 import { useErrorFlag } from "@hooks/useErrorFlag";
 
@@ -22,8 +23,9 @@ function CertificationsOptions() {
     error,
   } = useHumanResourceRequests<ICertificationsTable>(
     formatHumanResourceData,
-    "certification",
+    ERequestType.certification,
   );
+
   const [tableData, setTableData] = useState<ICertificationsTable[]>([]);
 
   useEffect(() => {

--- a/src/pages/holidays/RequestEnjoyment/index.tsx
+++ b/src/pages/holidays/RequestEnjoyment/index.tsx
@@ -196,7 +196,7 @@ function RequestEnjoyment() {
     url: "/holidays",
   };
 
-  const humanResourceRequestType = ERequestType.VacationsEnjoyed;
+  const humanResourceRequestType = ERequestType.vacations_enjoyed;
   const humanResourceRequestDate = new Date().toISOString();
 
   return (

--- a/src/pages/holidays/RequestEnjoyment/index.tsx
+++ b/src/pages/holidays/RequestEnjoyment/index.tsx
@@ -128,7 +128,7 @@ function RequestEnjoyment() {
     setShowErrorFlag,
   } = useRequestSubmission(
     formValues,
-    "VacationsEnjoyed",
+    ERequestType.vacations_enjoyed,
     userCodeInCharge,
     userNameInCharge,
   );

--- a/src/pages/holidays/RequestPayment/index.tsx
+++ b/src/pages/holidays/RequestPayment/index.tsx
@@ -3,7 +3,10 @@ import { useNavigate } from "react-router-dom";
 import { FormikProps } from "formik";
 import { useMediaQuery } from "@inubekit/inubekit";
 
-import { IUnifiedHumanResourceRequestData } from "@ptypes/humanResourcesRequest.types";
+import {
+  IUnifiedHumanResourceRequestData,
+  ERequestType,
+} from "@ptypes/humanResourcesRequest.types";
 import { SendRequestModal } from "@components/modals/SendRequestModal";
 import { RequestInfoModal } from "@components/modals/RequestInfoModal";
 import { useErrorFlag } from "@hooks/useErrorFlag";
@@ -125,7 +128,7 @@ function RequestPayment() {
     setShowErrorFlag,
   } = useRequestSubmission(
     formValues,
-    "PaidVacations",
+    ERequestType.onboarding,
     userCodeInCharge,
     userNameInCharge,
   );

--- a/src/pages/holidays/RequestPayment/index.tsx
+++ b/src/pages/holidays/RequestPayment/index.tsx
@@ -128,7 +128,7 @@ function RequestPayment() {
     setShowErrorFlag,
   } = useRequestSubmission(
     formValues,
-    ERequestType.onboarding,
+    ERequestType.paid_vacations,
     userCodeInCharge,
     userNameInCharge,
   );

--- a/src/pages/holidays/config/table.config.tsx
+++ b/src/pages/holidays/config/table.config.tsx
@@ -16,7 +16,7 @@ export const formatHolidaysData = (holidays: HumanResourceRequest[]) =>
     const parsedData = parseDataSafely(holiday.humanResourceRequestData);
 
     const isPaidVacation =
-      holiday.humanResourceRequestType === ERequestType.PaidVacations;
+      holiday.humanResourceRequestType === ERequestType.paid_vacations;
 
     const daysValue = (getValueFromData(parsedData, "daysToPay", null) ??
       getValueFromData(parsedData, "daysOff", 0)) as number;
@@ -29,10 +29,7 @@ export const formatHolidaysData = (holidays: HumanResourceRequest[]) =>
       requestId: holiday.humanResourceRequestId,
       requestNumber: holiday.humanResourceRequestNumber,
       description: {
-        value:
-          ERequestType[
-            holiday.humanResourceRequestType as keyof typeof ERequestType
-          ],
+        value: holiday.humanResourceRequestType,
       },
       date: {
         value: formatDate(displayDate),

--- a/src/pages/holidays/config/table.config.tsx
+++ b/src/pages/holidays/config/table.config.tsx
@@ -3,6 +3,8 @@ import { MdOutlineVisibility, MdDeleteOutline } from "react-icons/md";
 import {
   ERequestType,
   HumanResourceRequest,
+  requestTypeMap,
+  requestTypeLabels,
 } from "@ptypes/humanResourcesRequest.types";
 import { Employee } from "@ptypes/employeePortalConsultation.types";
 import { formatDate } from "@utils/date";
@@ -25,11 +27,17 @@ export const formatHolidaysData = (holidays: HumanResourceRequest[]) =>
       ? (getValueFromData(parsedData, "disbursementDate", "") as string)
       : holiday.humanResourceRequestDate;
 
+    const typeKey = Object.entries(requestTypeMap).find(
+      ([, slug]) => slug === holiday.humanResourceRequestType,
+    )?.[0] as keyof typeof requestTypeMap | undefined;
+
     return {
       requestId: holiday.humanResourceRequestId,
       requestNumber: holiday.humanResourceRequestNumber,
       description: {
-        value: holiday.humanResourceRequestType,
+        value: typeKey
+          ? requestTypeLabels[typeKey as ERequestType]
+          : holiday.humanResourceRequestType,
       },
       date: {
         value: formatDate(displayDate),

--- a/src/pages/holidays/index.tsx
+++ b/src/pages/holidays/index.tsx
@@ -26,7 +26,7 @@ function HolidaysOptions() {
     rawData: rawEnjoyedData,
   } = useHumanResourceRequests<IHolidaysTable>(
     formatHolidaysData,
-    "VacationsEnjoyed",
+    "vacations_enjoyed",
   );
 
   const {
@@ -35,7 +35,7 @@ function HolidaysOptions() {
     rawData: rawPaidData,
   } = useHumanResourceRequests<IHolidaysTable>(
     formatHolidaysData,
-    "PaidVacations",
+    "paid_vacations",
   );
 
   const [tableData, setTableData] = useState<IHolidaysTable[]>([]);

--- a/src/pages/holidays/index.tsx
+++ b/src/pages/holidays/index.tsx
@@ -26,7 +26,7 @@ function HolidaysOptions() {
     rawData: rawEnjoyedData,
   } = useHumanResourceRequests<IHolidaysTable>(
     formatHolidaysData,
-    "vacations_enjoyed",
+    ERequestType.vacations_enjoyed,
   );
 
   const {
@@ -35,7 +35,7 @@ function HolidaysOptions() {
     rawData: rawPaidData,
   } = useHumanResourceRequests<IHolidaysTable>(
     formatHolidaysData,
-    "paid_vacations",
+    ERequestType.paid_vacations,
   );
 
   const [tableData, setTableData] = useState<IHolidaysTable[]>([]);

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -3,8 +3,9 @@ import { Text, Stack, Grid, Header, useMediaQuery } from "@inubekit/inubekit";
 
 import { AppCard } from "@components/feedback/AppCard";
 import { spacing } from "@design/tokens/spacing";
-import { userMenu, useConfigHeader, baseNavLinks } from "@config/nav.config";
+import { userMenu, useConfigHeader, navConfig } from "@config/nav.config";
 import { useAppContext } from "@context/AppContext";
+import { useEmployeeOptions } from "@hooks/useEmployeeOptions";
 
 import {
   StyledAppPage,
@@ -25,7 +26,10 @@ const renderLogo = (imgUrl: string, altText: string) => {
 
 function Home() {
   const { user, logoUrl, businessUnit } = useAppContext();
-  const configHeader = useConfigHeader();
+  const { data: employeeOptions } = useEmployeeOptions(user?.id ?? "");
+  const safeEmployeeOptions = employeeOptions ?? [];
+
+  const configHeader = useConfigHeader(safeEmployeeOptions);
   const isTablet = useMediaQuery("(max-width: 944px)");
 
   return (
@@ -62,7 +66,7 @@ function Home() {
                   Aquí tienes las funcionalidades disponibles.
                 </Text>
                 <StyledQuickAccessContainer $isTablet={isTablet}>
-                  {baseNavLinks.map((link, index) => (
+                  {navConfig(safeEmployeeOptions).map((link, index) => (
                     <AppCard
                       key={index}
                       title={link.label}
@@ -81,5 +85,4 @@ function Home() {
     </StyledAppPage>
   );
 }
-
 export { Home };

--- a/src/services/employeeConsultation/index.tsx
+++ b/src/services/employeeConsultation/index.tsx
@@ -5,6 +5,7 @@ import {
 } from "@config/environment";
 
 import { Employee } from "@ptypes/employeePortalConsultation.types";
+import { EContractStatus } from "@ptypes/employeePortalBusiness.types";
 
 import { mapEmployeeApiToEntity } from "./mappers";
 
@@ -25,7 +26,7 @@ const getAllEmployees = async (
         page: page.toString(),
         per_page: perPage.toString(),
         sort: "FirstName:asc",
-        contract_status: "formalized",
+        contract_status: EContractStatus.formalized,
       });
 
       const options: RequestInit = {

--- a/src/services/employeeConsultation/index.tsx
+++ b/src/services/employeeConsultation/index.tsx
@@ -25,7 +25,7 @@ const getAllEmployees = async (
         page: page.toString(),
         per_page: perPage.toString(),
         sort: "FirstName:asc",
-        contract_status: "Formalized",
+        contract_status: "formalized",
       });
 
       const options: RequestInit = {

--- a/src/services/employeePortal/getOptionsConsultation/mappers.ts
+++ b/src/services/employeePortal/getOptionsConsultation/mappers.ts
@@ -13,6 +13,7 @@ const mapEmployeeOptionsApiToEntity = (
   return options.map((option) => ({
     abbreviatedName: toStringSafe(option.abbreviatedName),
     descriptionUse: toStringSafe(option.descriptionUse),
+    iconReference: toStringSafe(option.iconReference),
     optionCode: toStringSafe(option.optionCode),
     optionEmployeeId: toStringSafe(option.optionEmployeeId),
     parentOptionId: toStringSafe(option.parentOptionId),

--- a/src/services/humanResourcesRequest/getHumanResourcesRequest/index.tsx
+++ b/src/services/humanResourcesRequest/getHumanResourcesRequest/index.tsx
@@ -5,15 +5,12 @@ import {
 } from "@config/environment";
 
 import { mapHumanResourceRequestApiToEntity } from "./mappers";
-import {
-  ERequestType,
-  HumanResourceRequest,
-} from "@ptypes/humanResourcesRequest.types";
+import { HumanResourceRequest } from "@ptypes/humanResourcesRequest.types";
 
 const getHumanResourceRequests = async (
   employeeId: string,
   headers: Record<string, string>,
-  typeRequest?: ERequestType,
+  typeRequest?: string,
 ): Promise<HumanResourceRequest[]> => {
   const maxRetries = maxRetriesServices;
   const fetchTimeout = fetchTimeoutServices;

--- a/src/services/humanResourcesRequest/getHumanResourcesRequest/index.tsx
+++ b/src/services/humanResourcesRequest/getHumanResourcesRequest/index.tsx
@@ -68,8 +68,6 @@ const getHumanResourceRequests = async (
           "Todos los intentos fallaron. No se pudo obtener las solicitudes de recursos humanos.",
         );
       }
-      // Espera antes del siguiente intento (opcional)
-      await new Promise((resolve) => setTimeout(resolve, 200));
     }
   }
 

--- a/src/services/humanResourcesRequest/getHumanResourcesRequest/index.tsx
+++ b/src/services/humanResourcesRequest/getHumanResourcesRequest/index.tsx
@@ -5,12 +5,16 @@ import {
 } from "@config/environment";
 
 import { mapHumanResourceRequestApiToEntity } from "./mappers";
+import {
+  ERequestType,
+  HumanResourceRequest,
+} from "@ptypes/humanResourcesRequest.types";
 
 const getHumanResourceRequests = async (
-  typeRequest: string,
   employeeId: string,
   headers: Record<string, string>,
-) => {
+  typeRequest?: ERequestType,
+): Promise<HumanResourceRequest[]> => {
   const maxRetries = maxRetriesServices;
   const fetchTimeout = fetchTimeoutServices;
 
@@ -18,11 +22,13 @@ const getHumanResourceRequests = async (
     try {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), fetchTimeout);
+
       const queryParameters = new URLSearchParams({
         employeeId,
-        humanResourceRequestType: typeRequest,
+        ...(typeRequest && { humanResourceRequestType: typeRequest }),
         sort: "desc.humanResourceRequestDate",
       });
+
       const res = await fetch(
         `${environment.IVITE_IPORTAL_EMPLOYEE_QUERY_PROCESS_SERVICE}/human-resources-requests?${queryParameters}`,
         {
@@ -62,6 +68,8 @@ const getHumanResourceRequests = async (
           "Todos los intentos fallaron. No se pudo obtener las solicitudes de recursos humanos.",
         );
       }
+      // Espera antes del siguiente intento (opcional)
+      await new Promise((resolve) => setTimeout(resolve, 200));
     }
   }
 

--- a/src/types/employeePortalBusiness.types.ts
+++ b/src/types/employeePortalBusiness.types.ts
@@ -162,10 +162,10 @@ interface IContractRemunerationAssignment {
 }
 
 export enum EContractStatus {
-  in_the_process_of_formalization = "in_the_process_of_formalization",
-  formalized = "Formalized",
-  finalized = "Finalized",
-  in_the_process_of_ending = "in_the_process_of_ending",
+  in_the_process_of_formalization = "En Proceso de Formalización",
+  formalized = "Formalizado",
+  finalized = "Finalizado",
+  in_the_process_of_ending = "En proceso de Finalizacion",
 }
 
 export type {

--- a/src/types/employeePortalBusiness.types.ts
+++ b/src/types/employeePortalBusiness.types.ts
@@ -162,10 +162,10 @@ interface IContractRemunerationAssignment {
 }
 
 export enum EContractStatus {
-  in_the_process_of_formalization = "En Proceso de Formalización",
-  formalized = "Formalizado",
-  finalized = "Finalizado",
-  in_the_process_of_ending = "En proceso de Finalizacion",
+  in_the_process_of_formalization = "in_the_process_of_formalization",
+  formalized = "formalized",
+  finalized = "finalized",
+  in_the_process_of_ending = "in_the_process_of_ending",
 }
 
 export type {

--- a/src/types/employeePortalBusiness.types.ts
+++ b/src/types/employeePortalBusiness.types.ts
@@ -162,10 +162,10 @@ interface IContractRemunerationAssignment {
 }
 
 export enum EContractStatus {
-  InTheProcessOfFormalization = "in_the_process_of_formalization",
-  Formalized = "Formalized",
-  Finalized = "Finalized",
-  InTheProcessOfEnding = "in_the_process_of_ending",
+  in_the_process_of_formalization = "in_the_process_of_formalization",
+  formalized = "Formalized",
+  finalized = "Finalized",
+  in_the_process_of_ending = "in_the_process_of_ending",
 }
 
 export type {

--- a/src/types/employeePortalBusiness.types.ts
+++ b/src/types/employeePortalBusiness.types.ts
@@ -120,8 +120,10 @@ interface UseCasesByBusinessesUnit {
 interface IEmployeeOptions {
   abbreviatedName: string;
   descriptionUse: string;
+  iconReference: string;
   optionCode: string;
   optionEmployeeId: string;
+  parentOptionId: string;
 }
 
 interface IVacationHistory {

--- a/src/types/humanResourcesRequest.types.ts
+++ b/src/types/humanResourcesRequest.types.ts
@@ -27,6 +27,21 @@ export const requestTypeMap: Record<ERequestType, string> = {
   [ERequestType.vacations_enjoyed]: "vacations_enjoyed",
 };
 
+export const requestTypeLabels: Record<ERequestType, string> = {
+  [ERequestType.absence]: "Ausencia",
+  [ERequestType.certification]: "Certificación",
+  [ERequestType.disability]: "Incapacidad",
+  [ERequestType.leave]: "Permiso",
+  [ERequestType.leaving_the_job]: "Retiro",
+  [ERequestType.onboarding]: "Vinculación",
+  [ERequestType.paid_vacations]: "Vacaciones Pagadas",
+  [ERequestType.position_transfer]: "Traslado de cargo",
+  [ERequestType.pqr]: "PQR",
+  [ERequestType.salary_increase]: "Ascenso salarial",
+  [ERequestType.unpaid_leave]: "Licencia no remunerada",
+  [ERequestType.vacations_enjoyed]: "Vacaciones Disfrutadas",
+};
+
 export enum ETaskStatus {
   assigned = "Asignada",
   executed = "Ejecutada",

--- a/src/types/humanResourcesRequest.types.ts
+++ b/src/types/humanResourcesRequest.types.ts
@@ -31,11 +31,17 @@ export enum HumanResourceRequestStatus {
 }
 
 export enum ERequestStatus {
-  canceled = "Cancelado",
-  closed = "Cerrado",
-  finished = "Finalizado",
-  supervisor_approval = "En progreso",
-  rejected = "Rechazado",
+  closed = "Cerrada",
+  rejected = "Rechazada",
+  canceled = "Cancelada",
+  supervisor_approval = "Aprobacion Jefe Inmediato",
+  HR_compliance_verification = "Verificacion en Gestion Humana",
+  confirmation_of_vacation_taken = "Confirmacion Disfrute de vacaciones",
+  successfully_processed = "Tramitada con Exito",
+  certification_generation = "Generacion de la certificacion",
+  onboarding_in_progress = "Vinculación en Progreso",
+  pending_registration_invitation = "Pendiente de Invitacion para registro",
+  pending_to_complete_registration = "Pendiente de completar registro",
 }
 
 export interface IUnifiedHumanResourceRequestData {

--- a/src/types/humanResourcesRequest.types.ts
+++ b/src/types/humanResourcesRequest.types.ts
@@ -8,10 +8,24 @@ export enum ERequestType {
   paid_vacations = "Vacaciones Pagadas",
   position_transfer = "Traslado de cargo",
   pqr = "PQR",
-  alary_increase = "Ascenso salarial",
+  salary_increase = "Ascenso salarial",
   unpaid_leave = "Licencia no remunerada",
   vacations_enjoyed = "Vacaciones Disfrutadas",
 }
+export const requestTypeMap: Record<ERequestType, string> = {
+  [ERequestType.absence]: "absence",
+  [ERequestType.certification]: "certification",
+  [ERequestType.disability]: "disability",
+  [ERequestType.leave]: "leave",
+  [ERequestType.leaving_the_job]: "leaving_the_job",
+  [ERequestType.onboarding]: "onboarding",
+  [ERequestType.paid_vacations]: "paid_vacations",
+  [ERequestType.position_transfer]: "position_transfer",
+  [ERequestType.pqr]: "pqr",
+  [ERequestType.salary_increase]: "salary_increase",
+  [ERequestType.unpaid_leave]: "unpaid_leave",
+  [ERequestType.vacations_enjoyed]: "vacations_enjoyed",
+};
 
 export enum ETaskStatus {
   assigned = "Asignada",

--- a/src/types/humanResourcesRequest.types.ts
+++ b/src/types/humanResourcesRequest.types.ts
@@ -1,16 +1,16 @@
 export enum ERequestType {
-  Absence = "Ausencia",
-  Certification = "Certificación",
-  Disability = "Incapacidad",
-  Leave = "Permiso",
-  LeavingTheJob = "Retiro",
-  Onboarding = "Vinculación",
-  PaidVacations = "Vacaciones Pagadas",
-  PositionTransfer = "Traslado de cargo",
-  PQR = "PQR",
-  SalaryIncrease = "Ascenso salarial",
-  UnpaidLeave = "Licencia no remunerada",
-  VacationsEnjoyed = "Vacaciones Disfrutadas",
+  absence = "Ausencia",
+  certification = "Certificación",
+  disability = "Incapacidad",
+  leave = "Permiso",
+  leaving_the_job = "Retiro",
+  onboarding = "Vinculación",
+  paid_vacations = "Vacaciones Pagadas",
+  position_transfer = "Traslado de cargo",
+  pqr = "PQR",
+  alary_increase = "Ascenso salarial",
+  unpaid_leave = "Licencia no remunerada",
+  vacations_enjoyed = "Vacaciones Disfrutadas",
 }
 
 export enum ETaskStatus {
@@ -31,11 +31,11 @@ export enum HumanResourceRequestStatus {
 }
 
 export enum ERequestStatus {
-  Canceled = "Cancelado",
-  Closed = "Cerrado",
-  Finished = "Finalizado",
+  canceled = "Cancelado",
+  closed = "Cerrado",
+  finished = "Finalizado",
   supervisor_approval = "En progreso",
-  Rejected = "Rechazado",
+  rejected = "Rechazado",
 }
 
 export interface IUnifiedHumanResourceRequestData {

--- a/src/types/humanResourcesRequest.types.ts
+++ b/src/types/humanResourcesRequest.types.ts
@@ -14,8 +14,8 @@ export enum ERequestType {
 }
 
 export enum ETaskStatus {
-  Assigned = "Asignada",
-  Executed = "Ejecutada",
+  assigned = "Asignada",
+  executed = "Ejecutada",
 }
 
 export enum HumanResourceRequestStatus {


### PR DESCRIPTION
# 📋 Descripción

Se ajustó la visualización de los tipos de solicitudes de talento humano para que se muestren en **español** en lugar de inglés.  
Este cambio asegura que los usuarios vean las traducciones correctas al consultar, crear o listar solicitudes.

---

# 🛠 Cambios realizados

- 🐞 Corrección de bug: traducciones de solicitudes ahora aparecen en **español**.  
- 🔧 Refactorización menor en el manejo de `ERequestType` y `requestTypeMap`.

---

# 🚦 ¿Cómo probar?

1. Ir a la vista de **Solicitudes de Talento Humano**.  
2. Revisar el listado de solicitudes (ejemplo: vacaciones, incapacidades, permisos, etc.).  

---

# ✅ Checklist - Estandar

- [x] El código sigue la guía de estilos.  
- [x] No se introducen errores en consola.  
- [x] Se probó en dispositivos/resoluciones relevantes.  

---

# 📕 Checklist - Criterios de aceptación

- [x] Los tipos de solicitud deben mostrarse en **español**.  
- [x] Debe mantenerse la correcta relación con los valores del backend.  

---

# 📚 Referencias

- ISSUE_NUMBER
