### PR TITLE
at/ihp253/set-id-number-and-type-after-login

### DIFF
--- a/src/pages/protectedRoutes/index.tsx
+++ b/src/pages/protectedRoutes/index.tsx
@@ -62,13 +62,17 @@ export function ProtectedRoutes() {
     codeError: BusinessUnit,
   } = useBusinessUnit(portalData);
 
-  const numberDoc = "1062905485";
+  const identificationNumber = user?.id ?? "";
+
   const {
     employee,
     loading: employeeLoading,
     error: employeeError,
     codeError: employeeCode,
-  } = useEmployeeByNickname(numberDoc ?? "", businessUnitData.publicCode ?? "");
+  } = useEmployeeByNickname(
+    identificationNumber ?? "",
+    businessUnitData.publicCode ?? "",
+  );
 
   const {
     data: employeeOptions,


### PR DESCRIPTION
## 📋 Descripción

Se ajusta el consumo del empleado en `ProtectedRoutes` para utilizar el número de identificación proveniente del contexto `iAuth`, reemplazando el valor hardcodeado previamente.  
De esta forma, la validación de datos se realiza con la información real del usuario autenticado.

## 🛠 Cambios realizados

- [x] Ajuste en `ProtectedRoutes` para usar `identificationNumber` desde `iAuth`.
- [x] Eliminación del valor quemado (`1062905485`).

## 🚦 ¿Cómo probar?

1. Iniciar sesión en el portal con un usuario válido.
2. Navegar a la sección protegida donde se consulta el empleado.
3. Verificar que los datos del empleado se consulten correctamente en base al número de identificación del usuario autenticado.

## ✅ Checklist - Estandar

- [x] El código sigue la guía de estilos.
- [x] No se introducen errores en consola.

## 📕 Checklist - Criterios de aceptación

- Se debe consultar al empleado usando el número de identificación de `iAuth`.
- No debe existir ningún valor hardcodeado en la consulta del empleado.

## 📚 Referencias

[253](https://github.com/orgs/selsa-inube/projects/17/views/5?pane=issue&itemId=127640886&issue=selsa-inube%7Cteam-codex%7C253)
