### PR TITLE
ihp285 Aparece un error cuando no hay opciones de menu.

### DIFF
--- a/src/hooks/useEmployeeOptions.ts
+++ b/src/hooks/useEmployeeOptions.ts
@@ -1,12 +1,17 @@
 import { useState, useEffect } from "react";
+
 import { getEmployeeOptions } from "@services/employeePortal/getOptionsConsultation";
 import { IEmployeeOptions } from "@ptypes/employeePortalBusiness.types";
+
+import { useSignOut } from "./useSignOut";
 
 export const useEmployeeOptions = (employeeId: string) => {
   const [data, setData] = useState<IEmployeeOptions[] | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [codeError, setCodeError] = useState<number | undefined>(undefined);
+
+  const { signOut } = useSignOut();
 
   useEffect(() => {
     const fetchOptions = async () => {
@@ -17,6 +22,7 @@ export const useEmployeeOptions = (employeeId: string) => {
         const options = await getEmployeeOptions();
         if (options.length === 0) {
           setError("No existen opciones para el empleado");
+          signOut("/error?code=1005");
         }
         setData(options);
         setLoading(false);


### PR DESCRIPTION
## 📋 Descripción
Se ajusto el hook para cerrar sesión cuando el servicio no retorna datos

## 🛠 Cambios realizados
- [ ] Nueva funcionalidad
- [x] Corrección de bug
- [ ] Refactorización
- [ ] Actualización de dependencias
- [ ] Mejoras de rendimiento
- [ ] Otros (especificar)

## 🚦 ¿Cómo probar?
1. realizar la prueba para evidenciar que cuando el servicio no devuelva datos o vengan vacíos se cierre la sesión y muestre el error 1005

## ✅ Checklist - Estandar
- [x] El código sigue la guía de estilos
- [x] Se agregaron/actualizaron pruebas unitarias (Si aplica cuando se crea en el storybook)
- [x] No se introducen errores en consola
- [x] Se probó en dispositivos/resoluciones relevantes (Si aplica)

## 📕 Checklist - Criterios de aceptación
- [x] Cuando no haya opciones en el menú o en la página de Home, se debe mostrar la página de error con el código 1005 y cerrar sesión.
- [x] Si tiene opciones, se deben mostrar en el menú y en la página de Home.

## 📚 Referencias
https://github.com/selsa-inube/team-codex/issues/285#issue-3479082348
